### PR TITLE
Bug/teams with not full lineup (#262)

### DIFF
--- a/src/endpoints/getTeam.ts
+++ b/src/endpoints/getTeam.ts
@@ -31,8 +31,8 @@ export const getTeam = (config: HLTVConfig) => async ({
 
   const players = toArray(t$('.bodyshot-team .col-custom')).map(playerEl => ({
     name: playerEl.attr('title')!,
-    id: Number(playerEl.attr('href')!.split('/')[2])
-  }))
+    id: Number(playerEl.attr('href')?.split('/')[2])
+  })).filter(player => player?.name);
 
   const recentResults: Result[] = toArray(t$('.team-row')).map(matchEl => ({
     matchID: Number(


### PR DESCRIPTION
* Added possibility to filter results by content

* i missunderstood HLTVConfig and realized I dont need to edit that one..

* added options as enums

* it should be an array now

* wops

* atleast it doesnt break the fetch when team doesnt have full lineup

* filtered out undefined players